### PR TITLE
added space after colon in article notifications

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -79,7 +79,7 @@ void NotificationManager::doNotify()
 
             // starting a new feed
             feedTitle = currentFeedTitle;
-            message += QStringLiteral("<p><b>%1:</b></p>").arg(feedTitle);
+            message += QStringLiteral("<p><b>%1: </b></p>").arg(feedTitle);
         }
         // check not exceeding maxNewArticlesShown per feed
         if (entriesCount <= maxNewArticlesShown) {


### PR DESCRIPTION
fixes issue:
<img width="311" height="118" alt="image" src="https://github.com/user-attachments/assets/d3d416dc-d6d1-4b4c-bd73-fffde82be0c5" />
